### PR TITLE
make pyfiglet truly optional

### DIFF
--- a/termdown.py
+++ b/termdown.py
@@ -21,7 +21,11 @@ import unicodedata
 import click
 from dateutil import tz
 from dateutil.parser import parse
-from pyfiglet import Figlet
+try:
+    from pyfiglet import Figlet
+    NO_FIGLET = False
+except ImportError:
+    NO_FIGLET = True
 
 
 click.disable_unicode_literals_warning = True
@@ -264,7 +268,8 @@ def countdown(
         click.echo("Unable to parse TIME value '{}'".format(timespec))
         exit(64)
     curses_lock, input_queue, quit_event = setup(stdscr)
-    figlet = Figlet(font=font)
+    if not no_figlet:
+        figlet = Figlet(font=font)
 
     if title and not no_figlet:
         title = figlet.renderText(title)
@@ -415,7 +420,8 @@ def stopwatch(
     **kwargs
 ):
     curses_lock, input_queue, quit_event = setup(stdscr)
-    figlet = Figlet(font=font)
+    if not no_figlet:
+        figlet = Figlet(font=font)
 
     if title and not no_figlet:
         title = figlet.renderText(title)
@@ -541,6 +547,8 @@ def main(**kwargs):
     \tSPACE\tPause (will delay absolute TIMESPEC)
     \tQ\tQuit
     """
+    if NO_FIGLET:
+        kwargs['no_figlet'] = True
     if kwargs['timespec']:
         curses.wrapper(countdown, **kwargs)
     else:


### PR DESCRIPTION
This PR was trigged by the `--no-figlet`, I thought that indicates termdown optionally depends on pyfiglet, but it's imported, and even with that option, an `Figlet` instance is still created and is not used. You can't even `--help` if pyfiglet isn't installed.

I would disable some options, such as `--font`, if pyfiglet fails to be imported, but I don't know how to deal with those decorators. Because such option is still left in help message, that could be confusing if the user isn't aware of pyfiglet.

It might be better to halt if not specify with `--no-figlet` when no pyfiglet available, but if the issue above can be done, then there is no issue in this. So, I decided not to do anything, just forcing the `NO_FIGLET` onto `kwargs['no_figlet']`.