### PR TITLE
Use print in place of curses.putp for title

### DIFF
--- a/termdown.py
+++ b/termdown.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     from Queue import Empty, Queue
 import re
+import os
 from subprocess import Popen
 from sys import exit, stderr
 from threading import Event, Lock, Thread
@@ -299,7 +300,7 @@ def countdown(
             if seconds_left > 0:
                 with curses_lock:
                     if not no_window_title:
-                        print("\r\033]2;{0}\007".format(countdown_text), end='')
+                        os.write(1, "\033]2;{0}\007".format(countdown_text).encode())
                     stdscr.erase()
                     draw_text(
                         stdscr,
@@ -379,7 +380,7 @@ def countdown(
                     extra_sleep = 0
                     while True:
                         with curses_lock:
-                            print("\r\033]2;{0}\007".format("/" if flip else "\\").encode())
+                            os.write(1, "\033]2;{0}\007".format("/" if flip else "\\").encode())
                             if text:
                                 draw_text(
                                     stdscr,
@@ -419,7 +420,7 @@ def countdown(
     finally:
         with curses_lock:
             if not no_window_title:
-                print("\r\033]2;\007", end='')
+                os.write(1, "\033]2;\007".encode())
         quit_event.set()
         input_thread.join()
 
@@ -459,7 +460,7 @@ def stopwatch(
                 countdown_text = format_seconds(seconds_elapsed, hide_seconds=no_seconds)
             with curses_lock:
                 if not no_window_title:
-                    print("\r\033]2;{0}\007".format(countdown_text), end='')
+                    os.write(1, "\033]2;{0}\007".format(countdown_text).encode())
                 stdscr.erase()
                 draw_text(
                     stdscr,
@@ -478,7 +479,7 @@ def stopwatch(
                     pause_start = datetime.now()
                     with curses_lock:
                         if not no_window_title:
-                            print("\r\033]2;{0}\007".format(countdown_text), end='')
+                            os.write(1, "\033]2;{0}\007".format(countdown_text).encode())
                         stdscr.erase()
                         draw_text(
                             stdscr,
@@ -499,7 +500,7 @@ def stopwatch(
     finally:
         with curses_lock:
             if not no_window_title:
-                print("\r\033]2;\007", end='')
+                os.write(1, "\033]2;\007".encode())
         quit_event.set()
         input_thread.join()
     raise CursesReturnValue((datetime.now() - sync_start).total_seconds())

--- a/termdown.py
+++ b/termdown.py
@@ -14,7 +14,7 @@ except ImportError:
 import re
 import os
 from subprocess import Popen
-from sys import exit, stderr
+from sys import exit, stderr, stdout
 from threading import Event, Lock, Thread
 from time import sleep
 import unicodedata
@@ -300,7 +300,7 @@ def countdown(
             if seconds_left > 0:
                 with curses_lock:
                     if not no_window_title:
-                        os.write(1, "\033]2;{0}\007".format(countdown_text).encode())
+                        os.write(stdout.fileno(), "\033]2;{0}\007".format(countdown_text).encode())
                     stdscr.erase()
                     draw_text(
                         stdscr,
@@ -380,7 +380,7 @@ def countdown(
                     extra_sleep = 0
                     while True:
                         with curses_lock:
-                            os.write(1, "\033]2;{0}\007".format("/" if flip else "\\").encode())
+                            os.write(stdout.fileno(), "\033]2;{0}\007".format("/" if flip else "\\").encode())
                             if text:
                                 draw_text(
                                     stdscr,
@@ -420,7 +420,7 @@ def countdown(
     finally:
         with curses_lock:
             if not no_window_title:
-                os.write(1, "\033]2;\007".encode())
+                os.write(stdout.fileno(), "\033]2;\007".encode())
         quit_event.set()
         input_thread.join()
 
@@ -460,7 +460,7 @@ def stopwatch(
                 countdown_text = format_seconds(seconds_elapsed, hide_seconds=no_seconds)
             with curses_lock:
                 if not no_window_title:
-                    os.write(1, "\033]2;{0}\007".format(countdown_text).encode())
+                    os.write(stdout.fileno(), "\033]2;{0}\007".format(countdown_text).encode())
                 stdscr.erase()
                 draw_text(
                     stdscr,
@@ -479,7 +479,7 @@ def stopwatch(
                     pause_start = datetime.now()
                     with curses_lock:
                         if not no_window_title:
-                            os.write(1, "\033]2;{0}\007".format(countdown_text).encode())
+                            os.write(stdout.fileno(), "\033]2;{0}\007".format(countdown_text).encode())
                         stdscr.erase()
                         draw_text(
                             stdscr,
@@ -500,7 +500,7 @@ def stopwatch(
     finally:
         with curses_lock:
             if not no_window_title:
-                os.write(1, "\033]2;\007".encode())
+                os.write(stdout.fileno(), "\033]2;\007".encode())
         quit_event.set()
         input_thread.join()
     raise CursesReturnValue((datetime.now() - sync_start).total_seconds())

--- a/termdown.py
+++ b/termdown.py
@@ -299,7 +299,7 @@ def countdown(
             if seconds_left > 0:
                 with curses_lock:
                     if not no_window_title:
-                        curses.putp("\033]2;{0}\007".format(countdown_text).encode())
+                        print("\r\033]2;{0}\007".format(countdown_text), end='')
                     stdscr.erase()
                     draw_text(
                         stdscr,
@@ -379,7 +379,7 @@ def countdown(
                     extra_sleep = 0
                     while True:
                         with curses_lock:
-                            curses.putp("\033]2;{0}\007".format("/" if flip else "\\").encode())
+                            print("\r\033]2;{0}\007".format("/" if flip else "\\").encode())
                             if text:
                                 draw_text(
                                     stdscr,
@@ -419,7 +419,7 @@ def countdown(
     finally:
         with curses_lock:
             if not no_window_title:
-                curses.putp("\033]2;\007".encode())
+                print("\r\033]2;\007", end='')
         quit_event.set()
         input_thread.join()
 
@@ -459,7 +459,7 @@ def stopwatch(
                 countdown_text = format_seconds(seconds_elapsed, hide_seconds=no_seconds)
             with curses_lock:
                 if not no_window_title:
-                    curses.putp("\033]2;{0}\007".format(countdown_text).encode())
+                    print("\r\033]2;{0}\007".format(countdown_text), end='')
                 stdscr.erase()
                 draw_text(
                     stdscr,
@@ -478,7 +478,7 @@ def stopwatch(
                     pause_start = datetime.now()
                     with curses_lock:
                         if not no_window_title:
-                            curses.putp("\033]2;{0}\007".format(countdown_text).encode())
+                            print("\r\033]2;{0}\007".format(countdown_text), end='')
                         stdscr.erase()
                         draw_text(
                             stdscr,
@@ -499,7 +499,7 @@ def stopwatch(
     finally:
         with curses_lock:
             if not no_window_title:
-                curses.putp("\033]2;\007".encode())
+                print("\r\033]2;\007", end='')
         quit_event.set()
         input_thread.join()
     raise CursesReturnValue((datetime.now() - sync_start).total_seconds())


### PR DESCRIPTION
Terminals (at least VTE-based ones) don't seem to catch the window title setter if curses.putp is used. 

Is anyone else is available to test this with alternate terminals, that'd be greatly appreciated. I might've not caught some of the possible caveats with doing this.