### PR TITLE
Added a feature: laps.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Torsten Rehn <torsten@rehn.email>
 Peter Hofmann <scm@uninformativ.de>
+Bennett Piater <bennett at piater dot name>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+WIP
+===
+
+* added the lap feature
+
 1.10.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Usage: termdown [OPTIONS] [TIMESPEC]
       R       Reset
       SPACE   Pause (will delay absolute TIMESPEC)
       Q       Quit
+  Stopwatch mode:
+      L       Lap (Save the time and start counting from 0)
 
 Options:
   -a, --alt-format       Use colon-separated time format

--- a/termdown.py
+++ b/termdown.py
@@ -36,6 +36,7 @@ TIMEDELTA_REGEX = re.compile(r'((?P<years>\d+)y ?)?'
 INPUT_PAUSE = 1
 INPUT_RESET = 2
 INPUT_EXIT = 3
+INPUT_LAP = 4
 
 
 def setup(stdscr):
@@ -443,6 +444,7 @@ def stopwatch(
     try:
         sync_start = datetime.now()
         seconds_elapsed = 0
+        laps = []
         while quit_after is None or seconds_elapsed < int(quit_after):
             figlet.width = stdscr.getmaxyx()[1]
             if alt_format:
@@ -486,6 +488,11 @@ def stopwatch(
                     break
                 elif input_action == INPUT_RESET:
                     sync_start = datetime.now()
+                    laps = []
+                    seconds_elapsed = 0
+                elif input_action == INPUT_LAP:
+                    laps.append((datetime.now() - sync_start).total_seconds())
+                    sync_start = datetime.now()
                     seconds_elapsed = 0
             seconds_elapsed = int((datetime.now() - sync_start).total_seconds())
     finally:
@@ -494,7 +501,7 @@ def stopwatch(
                 os.write(stdout.fileno(), "\033]2;\007".encode())
         quit_event.set()
         input_thread.join()
-    return (datetime.now() - sync_start).total_seconds()
+    return (datetime.now() - sync_start).total_seconds(), laps
 
 
 def input_thread_body(stdscr, input_queue, quit_event, curses_lock):
@@ -510,6 +517,8 @@ def input_thread_body(stdscr, input_queue, quit_event, curses_lock):
             input_queue.put(INPUT_PAUSE)
         elif key in ("r", "R"):
             input_queue.put(INPUT_RESET)
+        elif key in ("l", "L"):
+            input_queue.put(INPUT_LAP)
         sleep(0.01)
 
 
@@ -557,12 +566,24 @@ def main(**kwargs):
     \tR\tReset
     \tSPACE\tPause (will delay absolute TIMESPEC)
     \tQ\tQuit
+    Stopwatch mode:
+    \tL\tLap (Save the time and start counting from 0)
     """
     if kwargs['timespec']:
         curses.wrapper(countdown, **kwargs)
     else:
-        seconds_elapsed = curses.wrapper(stopwatch, **kwargs)
+        seconds_elapsed, laps = curses.wrapper(stopwatch, **kwargs)
+
+        for i in laps:
+            stderr.write("{:.3f}\t{}\n".format(i, format_seconds(int(i))))
         stderr.write("{:.3f}\t{}\n".format(seconds_elapsed, format_seconds(int(seconds_elapsed))))
+
+        if (len(laps) > 0):
+            laps.append(seconds_elapsed)
+            total_seconds = sum(laps)
+            average_seconds = total_seconds / len(laps)
+            stderr.write("{:.3f}\tavg\n".format(average_seconds))
+            stderr.write("{:.3f}\t{}\n".format(total_seconds, format_seconds(int(total_seconds))))
         stderr.flush()
 
 


### PR DESCRIPTION
This is a very straightforward feature addition for the stopwatch mode.

When the user presses `L`, the counter is reset, but the previous value is added to a queue.
The entire queue is then printed out when the program terminates (in addition to the normal output).
The reset key also empties the queue, as I thought that would be the expected behaviour.

I also added a `-V | --verbose` flag. When it is set, the total and average time of all laps are also output when the program terminates.

I updated the `README` and the `CHANGELOG` accordingly.

---

Let me know if I should change anything! :)
I would also recommend using `-v` for verbosity and `-V` for voice because GNU software tends to do that. I did not make that change because I didn't want to break any of the API or UI without prior feedback.