### PR TITLE
ncurses conditional requirement for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "click >= 2.0",
         "pyfiglet >= 0.7",
         "python-dateutil",
+        "windows-curses ; platform_system=='Windows'",
     ],
     py_modules=['termdown'],
     entry_points={


### PR DESCRIPTION
This line adds support for Windows. Installing windows-curses made the plugin work on Windows 10 using PowerShell.