### PR TITLE
Add --no-figlet-y-offset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,43 +17,49 @@ Usage: termdown [OPTIONS] [TIME]
       Q       Quit
 
 Options:
-  -a, --alt-format         Use colon-separated time format
-  -b, --blink              Flash terminal at end of countdown
-  -B, --no-bell            Don't ring terminal bell at end of countdown
-  -c, --critical N         Draw final N seconds in red and announce them
-                           individually with --voice or --exec-cmd (defaults
-                           to 3)
-  -f, --font FONT          Choose from http://www.figlet.org/examples.html
-  -p, --voice-prefix TEXT  Add TEXT to the beginning of --voice and --exec
-                           annunciations (except per-second ones)
-  -q, --quit-after N       Quit N seconds after countdown (use with -b or -t)
-                           or terminate stopwatch after N seconds
-  -s, --no-seconds         Don't show seconds (except for last minute of
-                           countdown and first minute of stopwatch)
-  -t, --text TEXT          Text to display at end of countdown
-  -T, --title TEXT         Text to display on top of countdown/stopwatch
-  -W, --no-window-title    Don't update terminal title with remaining/elapsed
-                           time
-  -v, --voice VOICE        Spoken countdown (at fixed intervals with per-
-                           second annunciations starting at --critical;
-                           requires `espeak` on Linux or `say` on macOS;
-                           choose VOICE from `say -v '?'` or `espeak
-                           --voices`)
-  -o, --outfile PATH       File to write current remaining/elapsed time to
-  --exec-cmd CMD           Runs CMD every second. '{0}' and '{1}' in CMD will
-                           be replaced with the remaining/elapsed number of
-                           seconds and a more sparse annunciation as in
-                           --voice, respectively. For example, to get a
-                           callout at five seconds only, use: --exec-cmd "if [
-                           '{0}' == '5' ]; then say -v Alex {1}; fi"
-  --no-figlet              Don't use ASCII art for display
-  --no-text-magic          Don't try to replace non-ASCII characters (use with
-                           -t)
-  --version                Show version and exit
-  -z, --time               Show current time instead of countdown/stopwatch
-  -Z, --time-format TEXT   Format for --time (defaults to "%H:%M:%S", ignores
-                           --no-seconds)
-  --help                   Show this message and exit
+  -a, --alt-format              Use colon-separated time format
+  -b, --blink                   Flash terminal at end of countdown
+  -B, --no-bell                 Don't ring terminal bell at end of countdown
+  -c, --critical N              Draw final N seconds in red and announce them
+                                individually with --voice or --exec-cmd
+                                (defaults to 3)
+  -f, --font FONT               Choose from
+                                http://www.figlet.org/examples.html
+  -p, --voice-prefix TEXT       Add TEXT to the beginning of --voice and
+                                --exec annunciations (except per-second ones)
+  -q, --quit-after N            Quit N seconds after countdown (use with -b or
+                                -t) or terminate stopwatch after N seconds
+  -s, --no-seconds              Don't show seconds (except for last minute of
+                                countdown and first minute of stopwatch)
+  -t, --text TEXT               Text to display at end of countdown
+  -T, --title TEXT              Text to display on top of countdown/stopwatch
+  -W, --no-window-title         Don't update terminal title with
+                                remaining/elapsed time
+  -v, --voice VOICE             Spoken countdown (at fixed intervals with per-
+                                second annunciations starting at --critical;
+                                requires `espeak` on Linux or `say` on macOS;
+                                choose VOICE from `say -v '?'` or `espeak
+                                --voices`)
+  -o, --outfile PATH            File to write current remaining/elapsed time
+                                to
+  --exec-cmd CMD                Runs CMD every second. '{0}' and '{1}' in CMD
+                                will be replaced with the remaining/elapsed
+                                number of seconds and a more sparse
+                                annunciation as in --voice, respectively. For
+                                example, to get a callout at five seconds
+                                only, use: --exec-cmd "if [ '{0}' == '5' ];
+                                then say -v Alex {1}; fi"
+  --no-figlet                   Don't use ASCII art for display
+  --no-figlet-y-offset INTEGER  Vertical offset within the terminal (only for
+                                --no-figlet)
+  --no-text-magic               Don't try to replace non-ASCII characters (use
+                                with -t)
+  --version                     Show version and exit
+  -z, --time                    Show current time instead of
+                                countdown/stopwatch
+  -Z, --time-format TEXT        Format for --time (defaults to "%H:%M:%S",
+                                ignores --no-seconds)
+  --help                        Show this message and exit.
 ```
 
 ```

--- a/termdown.py
+++ b/termdown.py
@@ -68,29 +68,31 @@ def setup(stdscr):
     return (curses_lock, input_queue, quit_event)
 
 
-def draw_text(stdscr, text, color=0, fallback=None, title=None):
+def draw_text(stdscr, text, color=0, fallback=None, title=None, no_figlet_y_offset=-1):
     """
     Draws text in the given color. Duh.
     """
     if fallback is None:
         fallback = text
     y, x = stdscr.getmaxyx()
+    effective_y = (y if no_figlet_y_offset < 0 else 1)
+    y_delta = (0 if no_figlet_y_offset < 0 else no_figlet_y_offset)
     if title:
         title = pad_to_size(title, x, 1)
         if "\n" in title.rstrip("\n"):
             # hack to get more spacing between title and body for figlet
             title += "\n" * 5
         text = title + "\n" + pad_to_size(text, x, len(text.split("\n")))
-    lines = pad_to_size(text, x, y).rstrip("\n").split("\n")
+    lines = pad_to_size(text, x, effective_y).rstrip("\n").split("\n")
 
     try:
         for i, line in enumerate(lines):
-            stdscr.insstr(i, 0, line, curses.color_pair(color))
+            stdscr.insstr(i + y_delta, 0, line, curses.color_pair(color))
     except:
-        lines = pad_to_size(fallback, x, y).rstrip("\n").split("\n")
+        lines = pad_to_size(fallback, x, effective_y).rstrip("\n").split("\n")
         try:
             for i, line in enumerate(lines[:]):
-                stdscr.insstr(i, 0, line, curses.color_pair(color))
+                stdscr.insstr(i + y_delta, 0, line, curses.color_pair(color))
         except:
             pass
     stdscr.refresh()
@@ -287,6 +289,7 @@ def countdown(
     no_seconds=False,
     no_text_magic=True,
     no_figlet=False,
+    no_figlet_y_offset=-1,
     no_window_title=False,
     time=False,
     time_format=None,
@@ -298,6 +301,8 @@ def countdown(
         raise click.BadParameter("Unable to parse TIME value '{}'".format(timespec))
     curses_lock, input_queue, quit_event = setup(stdscr)
     figlet = Figlet(font=font)
+    if not no_figlet:
+        no_figlet_y_offset = -1
 
     if title and not no_figlet:
         try:
@@ -347,6 +352,7 @@ def countdown(
                             color=1 if seconds_left <= critical else 0,
                             fallback=title + "\n" + countdown_text if title else countdown_text,
                             title=title,
+                            no_figlet_y_offset=no_figlet_y_offset,
                         )
                     except CharNotPrinted:
                         draw_text(stdscr, "E")
@@ -408,6 +414,7 @@ def countdown(
                                 color=3,
                                 fallback=countdown_text,
                                 title=title,
+                                no_figlet_y_offset=no_figlet_y_offset,
                             )
                         except CharNotPrinted:
                             draw_text(stdscr, "E")
@@ -469,6 +476,7 @@ def countdown(
                                     rendered_text,
                                     color=base_color if flip else 4,
                                     fallback=text,
+                                    no_figlet_y_offset=no_figlet_y_offset,
                                 )
                             else:
                                 draw_text(stdscr, "", color=base_color if flip else 4)
@@ -517,6 +525,7 @@ def stopwatch(
     exec_cmd=None,
     font=DEFAULT_FONT,
     no_figlet=False,
+    no_figlet_y_offset=-1,
     no_seconds=False,
     quit_after=None,
     title=None,
@@ -530,6 +539,8 @@ def stopwatch(
     curses_lock, input_queue, quit_event = setup(stdscr)
     figlet = Figlet(font=font)
 
+    if not no_figlet:
+        no_figlet_y_offset = -1
     if title and not no_figlet:
         try:
             title = figlet.renderText(title)
@@ -568,6 +579,7 @@ def stopwatch(
                         stopwatch_text if no_figlet else figlet.renderText(stopwatch_text),
                         fallback=stopwatch_text,
                         title=title,
+                        no_figlet_y_offset=no_figlet_y_offset,
                     )
                 except CharNotPrinted:
                     draw_text(stdscr, "E")
@@ -615,6 +627,7 @@ def stopwatch(
                                 color=3,
                                 fallback=stopwatch_text,
                                 title=title,
+                                no_figlet_y_offset=no_figlet_y_offset,
                             )
                         except CharNotPrinted:
                             draw_text(stdscr, "E")
@@ -713,6 +726,8 @@ def input_thread_body(stdscr, input_queue, quit_event, curses_lock):
                    "use: --exec-cmd \"if [ '{0}' == '5' ]; then say -v Alex {1}; fi\"")
 @click.option("--no-figlet", default=False, is_flag=True,
               help="Don't use ASCII art for display")
+@click.option("--no-figlet-y-offset", default=-1,
+              help="Vertical offset within the terminal (only for --no-figlet)")
 @click.option("--no-text-magic", default=False, is_flag=True,
               help="Don't try to replace non-ASCII characters (use with -t)")
 @click.option("--version", is_flag=True, callback=print_version,


### PR DESCRIPTION
To put the unadorned text at the top or bottom or wherever.

"I love it when a plan comes together" --
https://en.wikipedia.org/wiki/I_love_it_when_a_plan_comes_together

---

I hereby disclaim any implicit or explicit ownership of my changes in this
changeset, and put them under a multiple licence consisting of your choice of
one of more of:

- The CC0 / Public Domain - https://creativecommons.org/choose/zero/ .

- The MIT / Expat license - https://en.wikipedia.org/wiki/MIT_License

- The default licence of your project

- The https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License - version
2.1 or higher

- The https://en.wikipedia.org/wiki/GNU_General_Public_License - version 2 or
higher

- Any licence in the 2018-Aug-27 popular licenses list of
https://opensource.org/licenses

- The https://en.wikipedia.org/wiki/Apache_License version 2.0 or later

- The https://en.wikipedia.org/wiki/Artistic_License version 2.0 or later

- The https://en.wikipedia.org/wiki/ISC_license

- The https://opensource.org/licenses/BSD-2-Clause

Crediting me will be nice, but not mandatory, and you can change the licence
of the project without needing my permission.