### PR TITLE
Crude i18n for text-to-speech announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
                                 requires `espeak` on Linux or `say` on macOS;
                                 choose VOICE from `say -v '?'` or `espeak
                                 --voices`)
+  -l, --voice-language LANG     Language for voice
   -o, --outfile PATH            File to write current remaining/elapsed time
                                 to
   --exec-cmd CMD                Runs CMD every second. '{0}' and '{1}' in CMD

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     install_requires=[
         "click >= 2.0",
+        "i18n >= 0.2",
         "pyfiglet >= 0.7",
         "python-dateutil",
         "windows-curses ; platform_system=='Windows'",

--- a/termdown.py
+++ b/termdown.py
@@ -14,6 +14,7 @@ from sys import exit, stderr, stdout
 from threading import Event, Lock, Thread
 from time import sleep
 import unicodedata
+import i18n
 
 import click
 from dateutil import tz
@@ -282,6 +283,7 @@ def countdown(
     no_window_title=False,
     time=False,
     time_format=None,
+    voice_language=None,
     **kwargs
 ):
     try:
@@ -305,6 +307,12 @@ def countdown(
             if os.path.exists(cmd):
                 voice_cmd = cmd
                 break
+        i18n.set('fallback', 'en')
+        i18n.add_translation('{} seconds', '{} Sekunden', locale='de')
+        i18n.add_translation('{} seconds', '{} secondes', locale='fr')
+        i18n.add_translation('{} minutes', '{} Minuten', locale='de')
+        i18n.add_translation('one hour', 'Eine Stunde', locale='de')
+        i18n.add_translation('one hour', 'une heure', locale='fr')
     if voice or exec_cmd:
         voice_prefix = voice_prefix or ""
 
@@ -349,11 +357,11 @@ def countdown(
             if seconds_left <= critical:
                 annunciation = str(seconds_left)
             elif seconds_left in (5, 10, 20, 30, 60):
-                annunciation = "{} {} seconds".format(voice_prefix, seconds_left)
+                annunciation = "{} {}".format(voice_prefix, i18n.t("{} seconds", locale=voice_language).format(seconds_left))
             elif seconds_left in (300, 600, 1800):
-                annunciation = "{} {} minutes".format(voice_prefix, int(seconds_left / 60))
+                annunciation = "{} {}".format(voice_prefix, i18n.t("{} minutes", locale=voice_language).format(int(seconds_left / 60)))
             elif seconds_left == 3600:
-                annunciation = "{} one hour".format(voice_prefix)
+                annunciation = "{} {}".format(voice_prefix, i18n.t("one hour", locale=voice_language))
             if annunciation or exec_cmd:
                 if exec_cmd:
                     Popen(
@@ -692,6 +700,8 @@ def input_thread_body(stdscr, input_queue, quit_event, curses_lock):
                    "or --exec-cmd (defaults to 3)")
 @click.option("-f", "--font", default=DEFAULT_FONT, metavar="FONT",
               help="Choose from http://www.figlet.org/examples.html")
+@click.option("-l", "--voice-language", metavar="LANG",
+              help="Language for voice")
 @click.option("-p", "--voice-prefix", metavar="TEXT",
               help="Add TEXT to the beginning of --voice and --exec annunciations "
                    "(except per-second ones)")


### PR DESCRIPTION
Added an option to choose language for spoken announcements and a few sample translations. This does not change existing behaviour, it adds an option "-l [LANGUAGE]" that can be chosen to match the selected espeak voice and causes the program to use different text templates, falling back to the default English ones when no translation is specified.

Caveat:
While this works well for languages where the form of the numerals and "seconds" / "minutes" doesn't change when counting (German, French, Spanish, Turkish ... can basically just use a different template that follows the pattern for English, which is what I did for a first crude version of the feature), a proper pluralization library must be used for languages such as Russian or Polish where counting causes morphological changes that require more logic than just replacing the whole template. I did not attempt that here.