### PR TITLE
Display target of countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Options:
   -c, --critical N              Draw final N seconds in red and announce them
                                 individually with --voice or --exec-cmd
                                 (defaults to 3)
+  -e, --end                     Display target datetime of unpaused countdown
   -f, --font FONT               Choose from
                                 http://www.figlet.org/examples.html
   -p, --voice-prefix TEXT       Add TEXT to the beginning of --voice and

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
                                 countdown/stopwatch
   -Z, --time-format TEXT        Format for --time (defaults to "%H:%M:%S",
                                 ignores --no-seconds)
+  -D, --date-format TEXT        Format for --end (defaults to "%Y-%m-%d")
   --help                        Show this message and exit.
 ```
 

--- a/termdown.py
+++ b/termdown.py
@@ -58,7 +58,7 @@ def setup(stdscr):
     return (curses_lock, input_queue, quit_event)
 
 
-def draw_text(stdscr, text, color=0, fallback=None, title=None, no_figlet_y_offset=-1):
+def draw_text(stdscr, text, color=0, fallback=None, title=None, no_figlet_y_offset=-1, end=None):
     """
     Draws text in the given color. Duh.
     """
@@ -73,6 +73,9 @@ def draw_text(stdscr, text, color=0, fallback=None, title=None, no_figlet_y_offs
             # hack to get more spacing between title and body for figlet
             title += "\n" * 5
         text = title + "\n" + pad_to_size(text, x, len(text.split("\n")))
+    if end:
+        end = pad_to_size(end, x, 1)
+        text = pad_to_size(text, x, len(text.split("\n"))) + "\n" + end
     lines = pad_to_size(text, x, effective_y).rstrip("\n").split("\n")
 
     try:
@@ -132,6 +135,15 @@ def format_seconds_alt(seconds, start, hide_seconds=False):
             output += "00:"
         seconds = seconds % period_seconds
     return output.rstrip(":")
+
+
+def format_target(target, time_format, date_format):
+    """
+    Returns a human-readable string representation of the countdown's target
+    datetime
+    """
+    fmt = f'{date_format} {time_format}' if datetime.now().date() != target.date() else time_format  # Only include date if countdown ends on a day that isn't today
+    return f'Ends at {target.strftime(fmt)}'
 
 
 def graceful_ctrlc(func):
@@ -271,6 +283,7 @@ def countdown(
     text=None,
     timespec=None,
     title=None,
+    end=None,
     voice=None,
     voice_prefix=None,
     exec_cmd=None,
@@ -343,6 +356,7 @@ def countdown(
                             color=1 if seconds_left <= critical else 0,
                             fallback=title + "\n" + countdown_text if title else countdown_text,
                             title=title,
+                            end=end and format_target(target, time_format=time_format, date_format=date_format),
                             no_figlet_y_offset=no_figlet_y_offset,
                         )
                     except CharNotPrinted:
@@ -692,6 +706,8 @@ def input_thread_body(stdscr, input_queue, quit_event, curses_lock):
 @click.option("-c", "--critical", default=3, metavar="N",
               help="Draw final N seconds in red and announce them individually with --voice "
                    "or --exec-cmd (defaults to 3)")
+@click.option("-e", "--end", default=False, is_flag=True,
+              help="Display target datetime of unpaused countdown")
 @click.option("-f", "--font", default=DEFAULT_FONT, metavar="FONT",
               help="Choose from http://www.figlet.org/examples.html")
 @click.option("-p", "--voice-prefix", metavar="TEXT",
@@ -733,7 +749,7 @@ def input_thread_body(stdscr, input_queue, quit_event, curses_lock):
 @click.option("-z", "--time", default=False, is_flag=True,
               help="Show current time instead of countdown/stopwatch")
 @click.option("-Z", "--time-format", default=None,
-              help="Format for --time (defaults to \"{}\", "
+              help="Format for --time/--end (defaults to \"{}\", "
                    "ignores --no-seconds)".format(DEFAULT_TIME_FORMAT))
 @click.option("-D", "--date-format", default=None,
               help="Format for --end (defaults to \"{}\")".format(DEFAULT_DATE_FORMAT))

--- a/termdown.py
+++ b/termdown.py
@@ -23,6 +23,7 @@ from pyfiglet import CharNotPrinted, Figlet
 
 DEFAULT_FONT = "univers"
 DEFAULT_TIME_FORMAT = "%H:%M:%S"  # --no-seconds expects this to end with :%S
+DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 TIMEDELTA_REGEX = re.compile(r'((?P<years>\d+)y ?)?'
                              r'((?P<days>\d+)d ?)?'
                              r'((?P<hours>\d+)h ?)?'
@@ -282,6 +283,7 @@ def countdown(
     no_window_title=False,
     time=False,
     time_format=None,
+    date_format=None,
     **kwargs
 ):
     try:
@@ -733,6 +735,8 @@ def input_thread_body(stdscr, input_queue, quit_event, curses_lock):
 @click.option("-Z", "--time-format", default=None,
               help="Format for --time (defaults to \"{}\", "
                    "ignores --no-seconds)".format(DEFAULT_TIME_FORMAT))
+@click.option("-D", "--date-format", default=None,
+              help="Format for --end (defaults to \"{}\")".format(DEFAULT_DATE_FORMAT))
 @click.argument('timespec', metavar="[TIME]", required=False)
 def main(**kwargs):
     """
@@ -754,6 +758,8 @@ def main(**kwargs):
     if kwargs['time_format'] is None:
         kwargs['time_format'] = \
                 DEFAULT_TIME_FORMAT[:-3] if kwargs['no_seconds'] else DEFAULT_TIME_FORMAT
+    if kwargs['date_format'] is None:
+        kwargs['date_format'] = DEFAULT_DATE_FORMAT
 
     if kwargs['timespec']:
         curses.wrapper(countdown, **kwargs)


### PR DESCRIPTION
This PR adds a couple of options to support displaying the target datetime of the active countdown.

A picture is worth a thousand words:
![image](https://user-images.githubusercontent.com/5025277/99121916-2760e500-25b2-11eb-8508-963176fdd6ac.png)

My initial implementation has a limitation: **While the countdown is paused, the target isn't incrementing.**  I haven't done a whole lot of digging into how to rejigger pausing in such a way that it causes the countdown to stop but continues drawing frames so the target can continue incrementing.  Was hoping to get some ideas from here.  Currently, pausing the countdown simply hides the target, so it's not misleading.

Some details:

- If the countdown ends on a different day than today, the displayed target includes a date as well as a time
- The time format uses the existing default introduced by `--time-format` and can be controlled with `--time-format`
- The date format uses a default I've introduced and can be controlled with `--date-format` which I've also introduced