### PR TITLE
Change exit value from zero to one if pressed q during countdown or stopwatch

### DIFF
--- a/termdown.py
+++ b/termdown.py
@@ -413,7 +413,7 @@ def countdown(
                         sync_start += time_paused
                         target += time_paused
                 if input_action == INPUT_EXIT:  # no elif here! input_action may have changed
-                    break
+                    raise KeyboardInterrupt
                 elif input_action == INPUT_RESET:
                     sync_start, target = parse_timestr(timespec)
                     seconds_left = int(ceil((target - datetime.now()).total_seconds()))
@@ -487,7 +487,7 @@ def countdown(
                             extra_sleep = (sleep_end - sleep_start).total_seconds()
                         if input_action == INPUT_EXIT:
                             # no elif here! input_action may have changed
-                            return
+                            raise KeyboardInterrupt
                         elif input_action == INPUT_RESET:
                             sync_start, target = parse_timestr(timespec)
                             seconds_left = int(ceil((target - datetime.now()).total_seconds()))


### PR DESCRIPTION
Since I like to have played a sound after the end of the countdown, but don't need the sound when I quit the countdown with 'q', I changed the exit value to one. This allows differentiating in a following command if the countdown ended normally or was interrupted by the user.