### PR TITLE
Add notification argument and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+uv.lock
+termdown/__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "Pillow",
     "python-dateutil",
     "windows-curses; platform_system == 'Windows'",
+    "desktop-notifier"
 ]
 
 [project.scripts]

--- a/termdown/cli.py
+++ b/termdown/cli.py
@@ -164,6 +164,12 @@ parser.add_argument(
     "--no-art", action="store_true", help="Don't use ASCII art for display"
 )
 parser.add_argument(
+    "-n",
+    "--notification",
+    metavar="NOTIFICATION_TEXT",
+    help="Sends notification when the countdown stops (Linux only for now)",
+)
+parser.add_argument(
     "--no-text-magic",
     action="store_true",
     help="Don't try to replace non-ASCII characters (use with -t)",

--- a/termdown/cli.py
+++ b/termdown/cli.py
@@ -167,7 +167,7 @@ parser.add_argument(
     "-n",
     "--notification",
     metavar="NOTIFICATION_TEXT",
-    help="Sends notification when the countdown stops (Linux only for now)",
+    help="Sends notification when the countdown stops (Not avalible in TTY)",
 )
 parser.add_argument(
     "--no-text-magic",

--- a/termdown/modes.py
+++ b/termdown/modes.py
@@ -38,6 +38,8 @@ def countdown(ui, args):
                 # If seconds_left is zero or negative, immediately break to handle the
                 # "finished" state. This prevents displaying "0" for an entire second
                 # while waiting for the next tick.
+                if not args.notification == None:
+                    os.system(f'notify-send "{args.notification}"')                    
                 break
 
             if args.alt_format:

--- a/termdown/modes.py
+++ b/termdown/modes.py
@@ -1,4 +1,6 @@
 import os
+import asyncio
+from desktop_notifier import DesktopNotifier
 from curses import beep
 from datetime import datetime, timedelta, timezone
 from math import ceil
@@ -24,6 +26,9 @@ from .utils import (
     parse_timestr,
 )
 
+async def notify(message):
+    notifier = DesktopNotifier()
+    await notifier.send(title="Termdown", message=message)
 
 def countdown(ui, args):
     target_time = parse_timestr(args.timespec)
@@ -39,7 +44,7 @@ def countdown(ui, args):
                 # "finished" state. This prevents displaying "0" for an entire second
                 # while waiting for the next tick.
                 if not args.notification == None:
-                    os.system(f'notify-send "{args.notification}"')                    
+                    asyncio.run(notify(args.notification))
                 break
 
             if args.alt_format:


### PR DESCRIPTION
This commit adds a new argument for notifications and displays them using the desktop_notifier module when the countdown reaches zero.

Example: termdown --notification="check on chicken" 30m